### PR TITLE
fix some style inconsistencies with husky and in setup vs non-setup flow

### DIFF
--- a/AndroidProducts.mk
+++ b/AndroidProducts.mk
@@ -8,3 +8,7 @@ PRODUCT_MAKEFILES := \
     $(LOCAL_DIR)/64bitonly/product/sdk_slim_arm64.mk \
     $(LOCAL_DIR)/fvpbase/fvp.mk \
     $(LOCAL_DIR)/fvpbase/fvp_mini.mk
+
+# Setup Wizard device-specific settings
+PRODUCT_SYSTEM_PROPERTIES += \
+    setupwizard.theme=glif_v4_light \

--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -101,4 +101,7 @@
     <bool name="config_supportMicNearUltrasound">true</bool>
     <bool name="config_supportSpeakerNearUltrasound">true</bool>
 
+    <bool name="config_buttonTextAllCaps">false</bool>
+    <dimen name="config_buttonCornerRadius">4dp</dimen>
+
 </resources>


### PR DESCRIPTION
- set the button text all-caps and corner radius values
   - the values match the ones being set by adevtool generated vendor module for husky
   - this is done to make husky and emulator similar in this context
- adds sysprop setupwizard.theme
    - this fixes the style inconsistencies in sud components being used in
non-setup flow

fixes: https://github.com/GrapheneOS/os-issue-tracker/issues/3471 for goldfish

Without fix     | With fix 
:-------------------------:|:-------------------------:
![](https://github.com/GrapheneOS/device_generic_goldfish/assets/13469327/4be52883-fb69-4b84-9e0d-f98cf723bb1c)  |  ![](https://github.com/GrapheneOS/device_generic_goldfish/assets/13469327/0a25844c-e25d-4a46-8eea-1aee0e7b1a10)